### PR TITLE
added flatMap to the JsonCollection class

### DIFF
--- a/src/main/scala/net/hamnaberg/json/collection/model.scala
+++ b/src/main/scala/net/hamnaberg/json/collection/model.scala
@@ -42,6 +42,8 @@ case class JsonCollection private[collection](underlying: JObject) extends Exten
   def isError = error.isDefined
 
   def map[B](f: (Item) => B): List[B] = items.map(f)
+  
+  def flatMap[B](f: (Item) => List[B]): List[B] = items.flatMap(f)
 
   def filter(f: (Item) => Boolean): List[Item] = items.filter(f)
 


### PR DESCRIPTION
When doing nested data transformation om properties of the collection, it's most useful to use flatMap(f) instead of depending on the scala flatten implementation of the collection returned by function f
