### PR TITLE
upgrade json4s-native to 3.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,6 @@ description := "Collection+JSON"
 
 name := "scala-json-collection"
 
-libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.10"
+libraryDependencies += "org.json4s" %% "json4s-native" % "3.3.0"
 
 libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"


### PR DESCRIPTION
Had some strange compatibility issues with the old version. Upgrading it in this library resolved the issue for me. 

From what I have found out it looks like some breaking changes in around 3.2.10 and 3.2.11.
